### PR TITLE
Add the EmptyDirectorySnapshot class (fixes #612)

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -11,8 +11,8 @@ Changelog
 Other Changes
 =============
 
--
-- Thanks to our beloved contributors:
+- [snapshot] Added EmptyDirectorySnapshot (`#613 <https://github.com/gorakhargosh/watchdog/pull/613>`__)
+- Thanks to our beloved contributors: @Ajordat
 
 
 0.10.0

--- a/src/watchdog/utils/dirsnapshot.py
+++ b/src/watchdog/utils/dirsnapshot.py
@@ -42,6 +42,10 @@ Classes
    :members:
    :show-inheritance:
 
+.. autoclass:: DirectorySnapshotEmpty
+   :members:
+   :show-inheritance:
+
 """
 
 import errno
@@ -347,3 +351,30 @@ class DirectorySnapshot(object):
 
     def __repr__(self):
         return str(self._stat_info)
+
+
+class EmptyDirectorySnapshot(object):
+    """Class to implement an empty snapshot. This is used together with
+    DirectorySnapshot and DirectorySnapshotDiff in order to get all the files/folders
+    in the directory as created.
+    """
+
+    @staticmethod
+    def path(_):
+        """Mock up method to return the path of the received inode. As the snapshot
+        is intended to be empty, it always returns None.
+
+        :returns:
+            None.
+        """
+        return None
+
+    @property
+    def paths(self):
+        """Mock up method to return a set of file/directory paths in the snapshot. As
+        the snapshot is intended to be empty, it always returns an empty set.
+
+        :returns:
+            An empty set.
+        """
+        return set()


### PR DESCRIPTION
* Added DirectorySnapshotEmpty (#612).

* Added test to show (and test) the usage of DirectorySnapshotEmpty (#612).

* Added sphinx class for DirectorySnapshotEmpty.

* Changed class name from DirectorySnapshotEmpty to EmptyDirectorySnapshot.

* Added documentation.

* Small doc fix.

* Updated changelog.rst.