### PR TITLE
Bump test sleep time from 10ms to 100ms on macos (#768)

### DIFF
--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -359,7 +359,7 @@ def test_fast_subdirectory_creation_deletion():
     for _ in range(times):
         mkdir(sub_dir)
         rm(sub_dir, True)
-        time.sleep(0.01)  # required for macOS emitter to catch up with us
+        time.sleep(0.1)  # required for macOS emitter to catch up with us
     count = {DirCreatedEvent: 0,
              DirModifiedEvent: 0,
              DirDeletedEvent: 0}


### PR DESCRIPTION
For some reason on macOS Big Sur with Apple silicon 10ms is not always enough.